### PR TITLE
gzip'd spec and params for http-oauth2 plugin

### DIFF
--- a/http_prompt/execution.py
+++ b/http_prompt/execution.py
@@ -30,7 +30,8 @@ from .utils import unescape, unquote, colformat
 
 HTTPIE_PROGRAM_NAME = 'http'
 
-
+# 210517 pa: extended grammar to reflect changes in options.py 
+#   to support 3 additional httpie-oauth2 authentication-plugin parameters
 grammar = r"""
     command = mutation / immutation
 
@@ -90,7 +91,8 @@ grammar = r"""
     value_optname = "--pretty" / "--style" / "-s" / "--print" / "-p" /
                     "--output" / "-o" / "--session-read-only" / "--session" /
                     "--auth-type" / "--auth" / "-a" / "--proxy" / "--verify" /
-                    "--cert" / "--cert-key" / "--timeout"
+                    "--cert" / "--cert-key" / "--timeout" / 
+                    "--token-url" / "--scope" / "--resource"
 
     cd = _ "cd" _ string? _
     rm = (_ "rm" _ "*" _) / (_ "rm" _ ~r"\-(h|q|b|o)" _ mutkey _)

--- a/http_prompt/options.py
+++ b/http_prompt/options.py
@@ -29,6 +29,13 @@ FLAG_OPTIONS = [
 VALUE_OPTIONS = [
     ('--auth', 'Do authentication'),
     ('--auth-type', 'Authentication mechanism to be used'),
+    
+    # 210517 pa: adding support for OAuth2 auth-plugin, 
+    #            which adds three dynamically argparse parameters
+    ('--token-url', 'OAuth2 plugin - Token URL'),
+    ('--scope',     'OAuth2 plugin - Scope'),
+    ('--resource',  'OAuth2 plugin - Resource'),
+
     ('--cert', 'Specify client SSL certificate'),
     ('--cert-key', 'The private key to use with SSL'),
     ('--output', 'Save output to a file'),


### PR DESCRIPTION
* added support for gzip'd `--spec` files
* added three parameters to support `http-oauth2` plugin
* extended grammar and added the three new parameters to be supported for tab-completion